### PR TITLE
Removed a prematurely added `;` that was preventing the module from being loaded

### DIFF
--- a/ionic.contrib.drawer.js
+++ b/ionic.contrib.drawer.js
@@ -172,7 +172,7 @@ angular.module('ionic.contrib.drawer', ['ionic'])
       };
     }
   }
-}]);
+}])
 
 .directive('drawerClose', ['$rootScope', function($rootScope) {
   return {


### PR DESCRIPTION
`ionic.contrib.drawer.js:177 Uncaught SyntaxError: Unexpected token .`
